### PR TITLE
import from joblib instead of sklearn.externals.joblib

### DIFF
--- a/skmultilearn/embedding/_mdsw.py
+++ b/skmultilearn/embedding/_mdsw.py
@@ -12,13 +12,23 @@ import warnings
 from sklearn.base import BaseEstimator
 from sklearn.metrics import euclidean_distances
 from sklearn.utils import check_random_state, check_array, check_symmetric
-from sklearn.externals.joblib import Parallel
-from sklearn.externals.joblib import delayed
+from joblib import Parallel
+from joblib import delayed
 from sklearn.isotonic import IsotonicRegression
 
 
-def _smacof_single_w(similarities, n_uq, uq_weight, metric=True, n_components=2, init=None,
-                     max_iter=300, verbose=0, eps=1e-3, random_state=None):
+def _smacof_single_w(
+    similarities,
+    n_uq,
+    uq_weight,
+    metric=True,
+    n_components=2,
+    init=None,
+    max_iter=300,
+    verbose=0,
+    eps=1e-3,
+    random_state=None,
+):
     """
     Computes multidimensional scaling using SMACOF algorithm
 
@@ -96,8 +106,9 @@ def _smacof_single_w(similarities, n_uq, uq_weight, metric=True, n_components=2,
         # overrides the parameter p
         n_components = init.shape[1]
         if n_samples != init.shape[0]:
-            raise ValueError("init matrix should be of shape (%d, %d)" %
-                             (n_samples, n_components))
+            raise ValueError(
+                "init matrix should be of shape (%d, %d)" % (n_samples, n_components)
+            )
         X = init
 
     old_stress = None
@@ -118,8 +129,9 @@ def _smacof_single_w(similarities, n_uq, uq_weight, metric=True, n_components=2,
             disparities = dis_flat.copy()
             disparities[sim_flat != 0] = disparities_flat
             disparities = disparities.reshape((n_samples, n_samples))
-            disparities *= np.sqrt((n_samples * (n_samples - 1) / 2) /
-                                   (disparities ** 2).sum())
+            disparities *= np.sqrt(
+                (n_samples * (n_samples - 1) / 2) / (disparities ** 2).sum()
+            )
 
         # Compute stress
         # stress = ((dis.ravel() - disparities.ravel()) ** 2).sum() / 2
@@ -135,7 +147,7 @@ def _smacof_single_w(similarities, n_uq, uq_weight, metric=True, n_components=2,
 
         dis[dis == 0] = 1e-5
         ratio = disparities / dis
-        _B = - W * ratio
+        _B = -W * ratio
         _B[np.arange(len(_B)), np.arange(len(_B))] += (W * ratio).sum(axis=1)
 
         X = np.dot(Vp, np.dot(_B, X))
@@ -144,21 +156,32 @@ def _smacof_single_w(similarities, n_uq, uq_weight, metric=True, n_components=2,
         dis = np.sqrt((X ** 2).sum(axis=1)).sum()
 
         if verbose >= 2:
-            print('it: %d, stress %s' % (it, stress))
+            print("it: %d, stress %s" % (it, stress))
         if old_stress is not None:
             if (old_stress - _stress / dis) < eps:
                 if verbose:
-                    print('breaking at iteration %d with stress %s' % (it,
-                                                                       stress))
+                    print("breaking at iteration %d with stress %s" % (it, stress))
                 break
         old_stress = _stress / dis
 
     return X, _stress, it + 1
 
 
-def _smacof_w(similarities, n_uq, uq_weight, metric=True, n_components=2, init=None, n_init=8,
-              n_jobs=1, max_iter=300, verbose=0, eps=1e-3, random_state=None,
-              return_n_iter=False):
+def _smacof_w(
+    similarities,
+    n_uq,
+    uq_weight,
+    metric=True,
+    n_components=2,
+    init=None,
+    n_init=8,
+    n_jobs=1,
+    max_iter=300,
+    verbose=0,
+    eps=1e-3,
+    random_state=None,
+    return_n_iter=False,
+):
     """
     Computes multidimensional scaling using SMACOF (Scaling by Majorizing a
     Complicated Function) algorithm
@@ -256,13 +279,13 @@ def _smacof_w(similarities, n_uq, uq_weight, metric=True, n_components=2, init=N
     similarities = check_array(similarities)
     random_state = check_random_state(random_state)
 
-    if hasattr(init, '__array__'):
+    if hasattr(init, "__array__"):
         init = np.asarray(init).copy()
         if not n_init == 1:
             warnings.warn(
-                'Explicit initial positions passed: '
-                'performing only one init of the MDS instead of %d'
-                % n_init)
+                "Explicit initial positions passed: "
+                "performing only one init of the MDS instead of %d" % n_init
+            )
             n_init = 1
 
     best_pos, best_stress = None, None
@@ -270,10 +293,17 @@ def _smacof_w(similarities, n_uq, uq_weight, metric=True, n_components=2, init=N
     if n_jobs == 1:
         for it in range(n_init):
             pos, stress, n_iter_ = _smacof_single_w(
-                similarities, n_uq, uq_weight, metric=metric,
-                n_components=n_components, init=init,
-                max_iter=max_iter, verbose=verbose,
-                eps=eps, random_state=random_state)
+                similarities,
+                n_uq,
+                uq_weight,
+                metric=metric,
+                n_components=n_components,
+                init=init,
+                max_iter=max_iter,
+                verbose=verbose,
+                eps=eps,
+                random_state=random_state,
+            )
             if best_stress is None or stress < best_stress:
                 best_stress = stress
                 best_pos = pos.copy()
@@ -282,10 +312,19 @@ def _smacof_w(similarities, n_uq, uq_weight, metric=True, n_components=2, init=N
         seeds = random_state.randint(np.iinfo(np.int32).max, size=n_init)
         results = Parallel(n_jobs=n_jobs, verbose=max(verbose - 1, 0))(
             delayed(_smacof_single_w)(
-                similarities, n_uq, uq_weight, metric=metric, n_components=n_components,
-                init=init, max_iter=max_iter, verbose=verbose, eps=eps,
-                random_state=seed)
-            for seed in seeds)
+                similarities,
+                n_uq,
+                uq_weight,
+                metric=metric,
+                n_components=n_components,
+                init=init,
+                max_iter=max_iter,
+                verbose=verbose,
+                eps=eps,
+                random_state=seed,
+            )
+            for seed in seeds
+        )
         positions, stress, n_iters = zip(*results)
         best = np.argmin(stress)
         best_stress = stress[best]
@@ -368,9 +407,20 @@ class _MDSW(BaseEstimator):
 
     """
 
-    def __init__(self, n_components=2, n_uq=1, uq_weight=None, metric=True, n_init=4,
-                 max_iter=300, verbose=0, eps=1e-3, n_jobs=1,
-                 random_state=None, dissimilarity="euclidean"):
+    def __init__(
+        self,
+        n_components=2,
+        n_uq=1,
+        uq_weight=None,
+        metric=True,
+        n_init=4,
+        max_iter=300,
+        verbose=0,
+        eps=1e-3,
+        n_jobs=1,
+        random_state=None,
+        dissimilarity="euclidean",
+    ):
         self.n_components = n_components
         self.n_uq = n_uq
         self.uq_weight = uq_weight
@@ -421,24 +471,37 @@ class _MDSW(BaseEstimator):
         """
         X = check_array(X)
         if X.shape[0] == X.shape[1] and self.dissimilarity != "precomputed":
-            warnings.warn("The MDS API has changed. ``fit`` now constructs an"
-                          " dissimilarity matrix from data. To use a custom "
-                          "dissimilarity matrix, set "
-                          "``dissimilarity=precomputed``.")
+            warnings.warn(
+                "The MDS API has changed. ``fit`` now constructs an"
+                " dissimilarity matrix from data. To use a custom "
+                "dissimilarity matrix, set "
+                "``dissimilarity=precomputed``."
+            )
 
         if self.dissimilarity == "precomputed":
             self.dissimilarity_matrix_ = X
         elif self.dissimilarity == "euclidean":
             self.dissimilarity_matrix_ = euclidean_distances(X)
         else:
-            raise ValueError("Proximity must be 'precomputed' or 'euclidean'."
-                             " Got %s instead" % str(self.dissimilarity))
+            raise ValueError(
+                "Proximity must be 'precomputed' or 'euclidean'."
+                " Got %s instead" % str(self.dissimilarity)
+            )
 
         self.embedding_, self.stress_, self.n_iter_ = _smacof_w(
-            self.dissimilarity_matrix_, self.n_uq, self.uq_weight, metric=self.metric,
-            n_components=self.n_components, init=init, n_init=self.n_init,
-            n_jobs=self.n_jobs, max_iter=self.max_iter, verbose=self.verbose,
-            eps=self.eps, random_state=self.random_state,
-            return_n_iter=True)
+            self.dissimilarity_matrix_,
+            self.n_uq,
+            self.uq_weight,
+            metric=self.metric,
+            n_components=self.n_components,
+            init=init,
+            n_init=self.n_init,
+            n_jobs=self.n_jobs,
+            max_iter=self.max_iter,
+            verbose=self.verbose,
+            eps=self.eps,
+            random_state=self.random_state,
+            return_n_iter=True,
+        )
 
         return self.embedding_


### PR DESCRIPTION
sklearn deprecated sklearn.externals.joblib and recommends to import directly from the package. This PR changes the imports to do such.